### PR TITLE
Require at least one Describe

### DIFF
--- a/src/powershellScripts.ts
+++ b/src/powershellScripts.ts
@@ -27,6 +27,10 @@ function Discover-Test
         $invokedViaInvokePester = $true
         $files = Find-File -Path $Path -ExcludePath $ExcludePath -Extension $PesterPreference.Run.TestExtension.Value
         $containers = foreach ($f in $files) {
+            <# HACK: We check to see if there is a single Describe block in the file so that we don't accidentally execute code that shouldn't need to be executed. #>
+            if (!(Select-String -Path $f -SimpleMatch 'Describe')) {
+                continue
+            }
             New-BlockContainerObject -File (Get-Item $f)
         }
         Find-Test -BlockContainer $containers -SessionState $SessionState } -Path $Path -ExcludePath $ExcludePath -SessionState $PSCmdlet.SessionState


### PR DESCRIPTION
Fixes #16 

This is a hack to prevent scripts that shouldn't be run from running. See the discussion in the issue.

cc @PrzemyslawKlys