### PR TITLE
Add config for test root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-pester-test-adapter",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -425,6 +425,15 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run your Pester tests in the Sidebar of Visual Studio Code",
   "icon": "img/test-explorer-pester.png",
   "publisher": "TylerLeonhardt",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "homepage": "https://github.com/TylerLeonhardt/vscode-pester-test-adapter",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run your Pester tests in the Sidebar of Visual Studio Code",
   "icon": "img/test-explorer-pester.png",
   "publisher": "TylerLeonhardt",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "homepage": "https://github.com/TylerLeonhardt/vscode-pester-test-adapter",
   "repository": {
@@ -41,7 +41,8 @@
   "devDependencies": {
     "@types/vscode": "~1.50.0",
     "typescript": "~4.1.2",
-    "vsce": "~1.81.1"
+    "vsce": "~1.81.1",
+    "rimraf": "3.0.2"
   },
   "engines": {
     "vscode": "^1.50.0"
@@ -69,7 +70,7 @@
           "type": "string",
           "scope": "resource"
         },
-        "pesterExplorer.testFilePath": {
+        "pesterExplorer.testResultsFilePath": {
           "description": "The path to the file _relative_ to your workspace. (i.e. `foo/TestExplorerResults.xml` would exist in a `foo` folder in the root of your workspace.)",
           "type": "string",
           "default": "TestExplorerResults.xml",
@@ -79,6 +80,11 @@
           "description": "If set to true, test discovery will be triggered when a workspace/folder is opened. If set to false, you will be prompted.",
           "type": "boolean",
           "default": false,
+          "scope": "resource"
+        },
+        "pesterExplorer.testRootDirectory": {
+          "description": "Specify the root directory of the location of your tests. Defaults to the Workspace/Folder root.",
+          "type": "string",
           "scope": "resource"
         }
       }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -34,7 +34,7 @@ export class PesterAdapter implements TestAdapter {
 		this.disposables.push(this.autorunEmitter);
 		this.pesterTestRunner = new PesterTestRunner(workspace, this.testStatesEmitter, log);
 
-		const rel = new vscode.RelativePattern(this.workspace, '**/*.[tT]ests.ps1');
+		const rel = new vscode.RelativePattern(this.pesterTestRunner.getTestRootDirectory(), '**/*.[tT]ests.ps1');
 		const testFilesWatcher = vscode.workspace.createFileSystemWatcher(rel, false, false, false);
 		testFilesWatcher.onDidChange(async (e: vscode.Uri) => {
 			this.testsEmitter.fire(<TestLoadStartedEvent>{ type: 'started' });


### PR DESCRIPTION
Adds the ability to set:

```
"pesterExplorer.testRootDirectory": "tests"
```

which accepts an absolute or relative path of where the root of your tests are. This defaults to the root of the workspace/folder you have open.

cc @PrzemyslawKlys for you, you'd do `"pesterExplorer.testRootDirectory": "Tests"`. I'd recommend adding it as a workspace setting in your repo.