### PR TITLE
Modifications to support defect #51

### DIFF
--- a/src/pesterTests.ts
+++ b/src/pesterTests.ts
@@ -84,7 +84,13 @@ export class PesterTestRunner {
 
 				let testSuiteInfo = null;
 				try {
-					const results = /{.+?"type": "suite",\s+"id": "root",\s+"label": "Pester",\s+"children".+}\s*$/si.exec(strData);
+
+					/*
+						defect-51 - Test Explorer does not show tests
+					    	JSON string contains multiple spaces between keyword and value - change regex expression to handle this
+					   		https://github.com/craiglemon
+					*/
+					const results = /{.+?"type":\s+"suite",\s+"id":\s+"root",\s+"label":\s+"Pester",\s+"children".+}\s*$/si.exec(strData);
 					if(!results || !results[0]) {
 						throw new Error('Regex does not match');
 					}

--- a/src/powershellScripts.ts
+++ b/src/powershellScripts.ts
@@ -11,9 +11,9 @@ $Path = @(
 #   ignore invalid argument - changed to SilentlyContinue or Continue as appropriate
 #   https://github.com/craiglemon
 
-# $VerbosePreference = 'SilentlyContinue'
-# $WarningPreference = 'Continue'
-# $DebugPreference = 'SilentlyContinue'
+$VerbosePreference = 'SilentlyContinue'
+$WarningPreference = 'Continue'
+$DebugPreference = 'SilentlyContinue'
 
 Import-Module Pester -MinimumVersion 5.0.0 -ErrorAction Stop
 function Discover-Test


### PR DESCRIPTION
Changes to support resolution of defect #51 as follows:
- Update to default preference values before Import-Module Pester command
- Added check for existence of Reset-TestSuiteState function before calling - deprecated in pester 5.2
- Pester 5.2 changed definition of Discover-Test return type - added version checking for such case
- JSON parsing regular expression needed inclusion of one or more space characters

Changes are backward compatible, but see a comment that this extension should support latest pester versions only, so perhaps my compatibility code could be removed if this is the desired outcome.

cheers, Craig